### PR TITLE
Replace missing Docker details

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "YOUR-DOCKER-HUB-ID/YOUR-IMAGE-NAME",
+    "Name": "cslsds/citrics-ds",
     "Update": "true"
   },
   "Ports": [


### PR DESCRIPTION
Somehow in some of my git-ineptitude and shuffling branches and commits carelessly, I lost the original edits to the Dockerrun.aws.json file, specifically the line that defines the docker hub id and docker image name:
`    "Name": "YOUR-DOCKER-HUB-ID/YOUR-IMAGE-NAME"`
this push replaces the placeholders with the location of the latest docker image:
`    "Name": "cslsds/citrics-ds"`